### PR TITLE
Fix discography sync wipe breaking CatalogueIndex.BandDiscographyId

### DIFF
--- a/src/MetalReleaseTracker.ParserService/Infrastructure/Data/Repositories/BandDiscographyRepository.cs
+++ b/src/MetalReleaseTracker.ParserService/Infrastructure/Data/Repositories/BandDiscographyRepository.cs
@@ -69,31 +69,26 @@ public class BandDiscographyRepository : IBandDiscographyRepository
     public async Task<DiscographySyncResult> ReplaceForBandAsync(Guid bandReferenceId, List<BandDiscographyEntity> entries, CancellationToken cancellationToken)
     {
         var existing = await _context.BandDiscography
-            .Where(d => d.BandReferenceId == bandReferenceId)
+            .Where(discography => discography.BandReferenceId == bandReferenceId)
             .ToListAsync(cancellationToken);
 
-        var existingTitles = new HashSet<string>(
-            existing.Select(e => e.NormalizedAlbumTitle),
-            StringComparer.OrdinalIgnoreCase);
+        var existingKeys = new HashSet<(string NormalizedAlbumTitle, int? Year)>(
+            existing.Select(discography => (discography.NormalizedAlbumTitle, discography.Year)));
 
-        var newAlbumTitles = entries
-            .Where(e => !existingTitles.Contains(e.NormalizedAlbumTitle))
-            .Select(e => e.AlbumTitle)
+        var toInsert = entries
+            .Where(entry => !existingKeys.Contains((entry.NormalizedAlbumTitle, entry.Year)))
             .ToList();
 
-        _context.BandDiscography.RemoveRange(existing);
-
-        if (entries.Count > 0)
+        if (toInsert.Count > 0)
         {
-            await _context.BandDiscography.AddRangeAsync(entries, cancellationToken);
+            await _context.BandDiscography.AddRangeAsync(toInsert, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
         }
-
-        await _context.SaveChangesAsync(cancellationToken);
 
         return new DiscographySyncResult
         {
             TotalCount = entries.Count,
-            NewAlbumTitles = newAlbumTitles,
+            NewAlbumTitles = toInsert.Select(entry => entry.AlbumTitle).ToList(),
         };
     }
 }

--- a/src/MetalReleaseTracker.ParserService/Infrastructure/Jobs/AlbumDetailParsingJob.cs
+++ b/src/MetalReleaseTracker.ParserService/Infrastructure/Jobs/AlbumDetailParsingJob.cs
@@ -223,7 +223,11 @@ public class AlbumDetailParsingJob
         }
 
         var changeReason = DetectChangeReason(existingDetail, albumParsedEvent);
-        if (changeReason != null)
+        var canonicalTitleRecovered =
+            string.IsNullOrWhiteSpace(existingDetail.CanonicalTitle)
+            && !string.IsNullOrWhiteSpace(albumParsedEvent.CanonicalTitle);
+
+        if (changeReason != null || canonicalTitleRecovered)
         {
             var existingPhotoUrl = existingDetail.PhotoUrl;
             MapAlbumFieldsToDetail(existingDetail, albumParsedEvent, entry);
@@ -289,8 +293,16 @@ public class AlbumDetailParsingJob
         detail.Description = source.Description;
         detail.Status = source.Status;
         detail.StockStatus = source.StockStatus;
-        detail.CanonicalTitle = source.CanonicalTitle;
-        detail.OriginalYear = source.OriginalYear;
+        if (!string.IsNullOrWhiteSpace(source.CanonicalTitle))
+        {
+            detail.CanonicalTitle = source.CanonicalTitle;
+        }
+
+        if (source.OriginalYear.HasValue)
+        {
+            detail.OriginalYear = source.OriginalYear;
+        }
+
         detail.MetalArchivesUrl = BuildMetalArchivesUrl(entry.BandReference);
     }
 

--- a/src/MetalReleaseTracker.ParserService/Tests/UnitTests/AlbumDetailParsingJobTests.cs
+++ b/src/MetalReleaseTracker.ParserService/Tests/UnitTests/AlbumDetailParsingJobTests.cs
@@ -190,6 +190,148 @@ public class AlbumDetailParsingJobTests
         Assert.Null(capturedDetail.OriginalYear);
     }
 
+    [Fact]
+    public async Task ParseRelevantEntries_ExistingDetailWithNullCanonicalTitle_UpdatesFieldsWhenDiscographyLinked()
+    {
+        var distributorCode = DistributorCode.Drakkar;
+        var discographyId = Guid.NewGuid();
+        var catalogueIndexId = Guid.NewGuid();
+
+        var catalogueEntry = new CatalogueIndexEntity
+        {
+            Id = catalogueIndexId,
+            DistributorCode = distributorCode,
+            BandName = "Drudkh",
+            AlbumTitle = "Autumn aurora",
+            DetailUrl = "https://example.com/detail",
+            Status = CatalogueIndexStatus.AiVerified,
+            BandDiscographyId = discographyId,
+            BandDiscography = new BandDiscographyEntity
+            {
+                Id = discographyId,
+                BandReferenceId = Guid.NewGuid(),
+                AlbumTitle = "Autumn Aurora",
+                NormalizedAlbumTitle = "autumn aurora",
+                AlbumType = "Full-length",
+                Year = 2004,
+            },
+        };
+
+        var existingDetail = new CatalogueIndexDetailEntity
+        {
+            Id = Guid.NewGuid(),
+            CatalogueIndexId = catalogueIndexId,
+            DistributorCode = distributorCode,
+            BandName = "Drudkh",
+            SKU = "2-drudkh-autumn-aurora",
+            Name = "Autumn aurora",
+            Price = 15.0f,
+            PurchaseUrl = "https://example.com/buy",
+            PhotoUrl = "https://example.com/photo.jpg",
+            CanonicalTitle = null,
+            OriginalYear = null,
+            ChangeType = ChangeType.New,
+            PublicationStatus = PublicationStatus.SkippedNoCanonicalTitle,
+        };
+
+        var parsedEvent = new AlbumParsedEvent
+        {
+            DistributorCode = distributorCode,
+            BandName = "Drudkh",
+            SKU = "2-drudkh-autumn-aurora",
+            Name = "Autumn aurora",
+            Price = 15.0f,
+            PurchaseUrl = "https://example.com/buy",
+            PhotoUrl = "https://example.com/photo.jpg",
+        };
+
+        CatalogueIndexDetailEntity? capturedDetail = null;
+        SetupMocksWithExistingDetail(distributorCode, catalogueEntry, existingDetail, parsedEvent, detail => capturedDetail = detail);
+
+        var job = CreateJob();
+        var dataSource = new ParserDataSource
+        {
+            DistributorCode = distributorCode,
+            Name = "Drakkar",
+            ParsingUrl = "https://example.com",
+        };
+
+        await job.RunDetailParsingJob(dataSource, CancellationToken.None);
+
+        Assert.NotNull(capturedDetail);
+        Assert.Equal("Autumn Aurora", capturedDetail!.CanonicalTitle);
+        Assert.Equal(2004, capturedDetail.OriginalYear);
+        Assert.Equal(ChangeType.Updated, capturedDetail.ChangeType);
+        Assert.Equal(PublicationStatus.Unpublished, capturedDetail.PublicationStatus);
+        Assert.Null(capturedDetail.ChangeReason);
+    }
+
+    [Fact]
+    public async Task ParseRelevantEntries_ExistingDetailWithCanonicalTitle_PreservesCanonicalTitleWhenSourceIsNull()
+    {
+        var distributorCode = DistributorCode.Drakkar;
+        var catalogueIndexId = Guid.NewGuid();
+
+        var catalogueEntry = new CatalogueIndexEntity
+        {
+            Id = catalogueIndexId,
+            DistributorCode = distributorCode,
+            BandName = "Drudkh",
+            AlbumTitle = "Autumn aurora",
+            DetailUrl = "https://example.com/detail",
+            Status = CatalogueIndexStatus.AiVerified,
+            BandDiscographyId = null,
+            BandDiscography = null,
+        };
+
+        var existingDetail = new CatalogueIndexDetailEntity
+        {
+            Id = Guid.NewGuid(),
+            CatalogueIndexId = catalogueIndexId,
+            DistributorCode = distributorCode,
+            BandName = "Drudkh",
+            SKU = "2-drudkh-autumn-aurora",
+            Name = "Autumn aurora",
+            Price = 15.0f,
+            PurchaseUrl = "https://example.com/buy",
+            PhotoUrl = "https://example.com/photo.jpg",
+            CanonicalTitle = "Autumn Aurora",
+            OriginalYear = 2004,
+            ChangeType = ChangeType.Updated,
+            PublicationStatus = PublicationStatus.Published,
+        };
+
+        var parsedEvent = new AlbumParsedEvent
+        {
+            DistributorCode = distributorCode,
+            BandName = "Drudkh",
+            SKU = "2-drudkh-autumn-aurora",
+            Name = "Autumn aurora",
+            Price = 17.0f,
+            PurchaseUrl = "https://example.com/buy",
+            PhotoUrl = "https://example.com/photo.jpg",
+        };
+
+        CatalogueIndexDetailEntity? capturedDetail = null;
+        SetupMocksWithExistingDetail(distributorCode, catalogueEntry, existingDetail, parsedEvent, detail => capturedDetail = detail);
+
+        var job = CreateJob();
+        var dataSource = new ParserDataSource
+        {
+            DistributorCode = distributorCode,
+            Name = "Drakkar",
+            ParsingUrl = "https://example.com",
+        };
+
+        await job.RunDetailParsingJob(dataSource, CancellationToken.None);
+
+        Assert.NotNull(capturedDetail);
+        Assert.Equal("Autumn Aurora", capturedDetail!.CanonicalTitle);
+        Assert.Equal(2004, capturedDetail.OriginalYear);
+        Assert.Equal(ChangeType.Updated, capturedDetail.ChangeType);
+        Assert.Equal(ChangeReason.PriceChange, capturedDetail.ChangeReason);
+    }
+
     private AlbumDetailParsingJob CreateJob()
     {
         return new AlbumDetailParsingJob(
@@ -250,5 +392,52 @@ public class AlbumDetailParsingJobTests
         _imageUploadServiceMock
             .Setup(service => service.UploadAlbumImageAsync(It.IsAny<ImageUploadRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ImageUploadResult.Success("blob/path.jpg", "https://example.com/photo.jpg"));
+    }
+
+    private void SetupMocksWithExistingDetail(
+        DistributorCode distributorCode,
+        CatalogueIndexEntity catalogueEntry,
+        CatalogueIndexDetailEntity existingDetail,
+        AlbumParsedEvent parsedEvent,
+        Action<CatalogueIndexDetailEntity> captureDetail)
+    {
+        _settingsServiceMock
+            .Setup(settingsService => settingsService.GetParsingSourceByCodeAsync(distributorCode, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ParsingSourceEntity
+            {
+                Id = Guid.NewGuid(),
+                DistributorCode = distributorCode,
+                Name = "Test Source",
+                ParsingUrl = "https://example.com",
+                IsEnabled = true,
+            });
+
+        _settingsServiceMock
+            .Setup(settingsService => settingsService.GetGeneralParserSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GeneralParserSettings
+            {
+                MinDelayBetweenRequestsSeconds = 0,
+                MaxDelayBetweenRequestsSeconds = 0,
+            });
+
+        _catalogueIndexRepoMock
+            .Setup(repository => repository.GetByStatusesWithDiscographyAsync(
+                distributorCode,
+                It.IsAny<IEnumerable<CatalogueIndexStatus>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<CatalogueIndexEntity> { catalogueEntry });
+
+        _catalogueIndexDetailRepoMock
+            .Setup(repository => repository.GetByCatalogueIndexIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingDetail);
+
+        _catalogueIndexDetailRepoMock
+            .Setup(repository => repository.UpdateAsync(It.IsAny<CatalogueIndexDetailEntity>(), It.IsAny<CancellationToken>()))
+            .Callback<CatalogueIndexDetailEntity, CancellationToken>((detail, _) => captureDetail(detail))
+            .Returns(Task.CompletedTask);
+
+        _parserMock
+            .Setup(parser => parser.ParseAlbumDetailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(parsedEvent);
     }
 }


### PR DESCRIPTION
## Summary

Parser detected changes weekly but CoreData stopped receiving them on 2026-04-11. Root cause is a weekly data-wipe bug in `BandDiscographyRepository.ReplaceForBandAsync` that silently destroys confirmed discography links, which cascades into `CanonicalTitle` being cleared and `AlbumPublisherJob` skipping everything as `SkippedNoCanonicalTitle`.

## Root cause

`BandReferenceSyncJob` runs every Sunday at 00:00 UTC. For each band, `ReplaceForBandAsync` did:
1. `_context.BandDiscography.RemoveRange(existing)` — wipes all discography rows for band
2. `AddRangeAsync(entries)` — inserts fresh rows with new UUIDs (even for unchanged albums)

FK `CatalogueIndex.BandDiscographyId -> BandDiscography.Id` has `ON DELETE SET NULL`. Every weekly sync:
- All `CatalogueIndex.BandDiscographyId` become NULL via FK cascade
- Next `AlbumDetailParsingJob` run: `entry.BandDiscography = null` → `albumParsedEvent.CanonicalTitle = null` → `MapAlbumFieldsToDetail` overwrites existing `CatalogueIndexDetails.CanonicalTitle` with NULL
- `AlbumPublisherJob` (commit 4e8b98f) hard-skips items with empty `CanonicalTitle` → `SkippedNoCanonicalTitle`

Evidence on prod:
- `CatalogueIndex`: 1061 AiVerified, only **28 linked** (1033 orphaned)
- `CatalogueIndexDetails`: 1005 rows, only **8 with CanonicalTitle** (997 NULL)
- CoreData `Albums`: **999 with CanonicalTitle** (published before the wipe cycles kicked in)
- Last successful publish: 2026-04-11 09:00 UTC

## Fixes

- **`BandDiscographyRepository.ReplaceForBandAsync`**: append-only by `(NormalizedAlbumTitle, Year)`. Existing entries are left untouched — their UUIDs are stable, and FK refs from `CatalogueIndex` survive weekly syncs. Only genuinely new albums are inserted.
- **`AlbumDetailParsingJob.UpsertDetailAsync`**: trigger the upsert path also when `CanonicalTitle` transitions from NULL to populated (data healing after AI verification links `BandDiscography` post-hoc). `ChangeReason` remains `null` for this case — this is not a user-visible price/status change.
- **`MapAlbumFieldsToDetail`**: never overwrite a non-empty `CanonicalTitle` / `OriginalYear` with NULL from a parse missing discography link (defence in depth).
- **Unit tests**: covers both the recovery path (NULL → value triggers upsert) and the preservation path (existing canonical title is kept when source has none).

## Test plan

- [x] `dotnet build` clean (0 errors)
- [x] `dotnet test` passes (5/5 in AlbumDetailParsingJobTests)
- [ ] One-time recovery after deploy (separate operation — not part of this PR):
  - [ ] SQL reset: `AiVerified AND BandDiscographyId IS NULL → Relevant` (~1033 items)
  - [ ] Re-run AI verification in admin UI
  - [ ] Bulk Confirm
  - [ ] Trigger `AlbumDetailParsingJob` per distributor via TickerQ dashboard
  - [ ] Verify CanonicalTitle populates on `CatalogueIndexDetails`, Publisher picks up, `AlbumChangeLogs.MAX(ChangedAt)` becomes recent, new Albums flow into CoreData