### PR TITLE
Fall back to sibling variant photo on album detail page

### DIFF
--- a/src/MetalReleaseTracker.CoreDataService/Services/Implementation/AlbumService.cs
+++ b/src/MetalReleaseTracker.CoreDataService/Services/Implementation/AlbumService.cs
@@ -165,40 +165,33 @@ public class AlbumService : IAlbumService
             return null;
         }
 
-        var photoUrl = await _fileStorageService.GetFileUrlAsync(album.PhotoUrl, cancellationToken);
-        var imageSet = await _imageUrlResolverService.ResolveImageUrlSetAsync(album.PhotoUrl, cancellationToken);
-
-        List<AlbumVariantDto> variants;
+        List<Data.Entities.AlbumEntity> matchingAlbums;
         if (!string.IsNullOrWhiteSpace(album.CanonicalTitle))
         {
-            var matchingAlbums = await _albumRepository.GetMatchingAlbumsAsync(
+            matchingAlbums = await _albumRepository.GetMatchingAlbumsAsync(
                 album.CanonicalTitle, album.Media, album.BandId, cancellationToken);
-
-            variants = matchingAlbums.Select(matchingAlbum => new AlbumVariantDto
-            {
-                AlbumId = matchingAlbum.Id,
-                DistributorId = matchingAlbum.DistributorId,
-                DistributorName = matchingAlbum.Distributor?.Name ?? string.Empty,
-                Price = matchingAlbum.Price,
-                PurchaseUrl = matchingAlbum.PurchaseUrl,
-                StockStatus = matchingAlbum.StockStatus
-            }).ToList();
         }
         else
         {
-            variants =
-            [
-                new AlbumVariantDto
-                {
-                    AlbumId = album.Id,
-                    DistributorId = album.DistributorId,
-                    DistributorName = album.Distributor?.Name ?? string.Empty,
-                    Price = album.Price,
-                    PurchaseUrl = album.PurchaseUrl,
-                    StockStatus = album.StockStatus
-                }
-            ];
+            matchingAlbums = [album];
         }
+
+        var photoSource = !string.IsNullOrWhiteSpace(album.PhotoUrl)
+            ? album
+            : matchingAlbums.FirstOrDefault(matchingAlbum => !string.IsNullOrWhiteSpace(matchingAlbum.PhotoUrl)) ?? album;
+
+        var photoUrl = await _fileStorageService.GetFileUrlAsync(photoSource.PhotoUrl, cancellationToken);
+        var imageSet = await _imageUrlResolverService.ResolveImageUrlSetAsync(photoSource.PhotoUrl, cancellationToken);
+
+        var variants = matchingAlbums.Select(matchingAlbum => new AlbumVariantDto
+        {
+            AlbumId = matchingAlbum.Id,
+            DistributorId = matchingAlbum.DistributorId,
+            DistributorName = matchingAlbum.Distributor?.Name ?? string.Empty,
+            Price = matchingAlbum.Price,
+            PurchaseUrl = matchingAlbum.PurchaseUrl,
+            StockStatus = matchingAlbum.StockStatus
+        }).ToList();
 
         var formatGroups = await BuildFormatGroupsAsync(album, cancellationToken);
 


### PR DESCRIPTION
## Summary

When a user clicks into a specific distributor variant on the album detail page (e.g. `/albums/drudkh-hra-tinei-shadow-play-13` → Black Metal Store CD), `AlbumService.GetAlbumDetail` used that variant's `PhotoUrl` directly. If that specific variant has no photo (or a broken/empty path), the detail card shows an empty image even though sibling variants in the same `(BandId, Media, CanonicalTitle)` group often have working photos.

## Fix

`AlbumService.GetAlbumDetail`:
- Move `GetMatchingAlbumsAsync` fetch above photo resolution so the same variant list feeds both the `Variants` DTO and the photo selection (removed a duplicate code path between the `CanonicalTitle`-present and `CanonicalTitle`-null branches).
- Prefer the current album's `PhotoUrl` when present (keeps UX consistent with what the user clicked), otherwise fall back to the first sibling with a non-empty `PhotoUrl`.

Grouped list view (`GetGroupedAlbums:103`) already had this fallback. Now detail view matches.

Scope-limited per request: related releases and format groups intentionally unchanged in this PR.

## Test plan

- [x] `dotnet build` clean (0 errors)
- [ ] Before: open `/albums/<slug>` where the specific variant has empty `PhotoUrl` → no image shown
- [ ] After: same URL → image from sibling variant appears
- [ ] Regression check: open `/albums/<slug>` where the variant has a photo → image unchanged (prefers current variant's photo)