### PR TITLE
Fix MinIO pre-signed URL SignatureDoesNotMatch for non-ASCII paths

### DIFF
--- a/src/MetalReleaseTracker.SharedLibraries/Minio/MinioFileStorageService.cs
+++ b/src/MetalReleaseTracker.SharedLibraries/Minio/MinioFileStorageService.cs
@@ -68,8 +68,6 @@ public class MinioFileStorageService : IFileStorageService
                 .WithObject(filePath)
                 .WithExpiry(60 * 60 * 24 * _config.PresignedUrlExpiryDays));
 
-            presignedUrl = System.Web.HttpUtility.UrlDecode(presignedUrl);
-
             if (!string.IsNullOrEmpty(_config.PublicEndpoint))
             {
                 presignedUrl = presignedUrl.Replace($"http://{_config.Endpoint}", _config.PublicEndpoint);


### PR DESCRIPTION
## Summary

Album cover images with Cyrillic characters in the object path (e.g. Black Metal Store, Drakkar variants of Ukrainian releases like `images/BlackMetalStore/...drudkh-гра-тіней-shadow-play-cd.jpg`) fail to load on the site with HTTP 403 `SignatureDoesNotMatch`. Latin-only paths work fine.

Evidence (captured via Playwright on `https://metal-release.com/albums/drudkh-hra-tinei-shadow-play-13`):
- Main cover URL (Cyrillic path) → `403 Forbidden`, XML body: `<Code>SignatureDoesNotMatch</Code>` with `<Key>images/BlackMetalStore/4-produto-cds-drudkh-гра-тіней-shadow-play-cd.jpg</Key>`
- 10+ other variants with ASCII-only paths → `200 OK`

## Root cause

`MinioFileStorageService.GetFileUrlAsync` was calling `System.Web.HttpUtility.UrlDecode` on the full pre-signed URL after the MinIO SDK generated it:

```csharp
var presignedUrl = await _minioClient.PresignedGetObjectAsync(...);
presignedUrl = System.Web.HttpUtility.UrlDecode(presignedUrl);  // ← bug
```

The SDK computes the AWS SigV4 signature over the URL-encoded object path (`%D0%B3%D1%80%D0%B0` for `гра`). `UrlDecode` converted those sequences back to raw Unicode in the URL while leaving `X-Amz-Signature` unchanged. When the browser later re-encoded the path to issue the HTTP request, MinIO recomputed the canonical request from the encoded form, got a different signature, and rejected with 403.

For ASCII-only paths `UrlDecode` is a no-op, which is why most images worked and only Cyrillic paths broke.

## Fix

Drop the `UrlDecode` call. The subsequent public endpoint rewrite (`Replace($"http://{_config.Endpoint}", _config.PublicEndpoint)`) still works because the MinIO SDK does not percent-encode the host portion.

## Test plan

- [x] `dotnet build` clean (0 errors)
- [ ] Post-deploy: open `https://metal-release.com/albums/drudkh-hra-tinei-shadow-play-13` → main album cover displays (Cyrillic path)
- [ ] Regression: open any album with ASCII-only path → cover still displays
- [ ] Regression: band pages, grouped album lists, notification images, album admin screens — all image URLs continue to work