### PR TITLE
Revert PR #25 (MinIO pre-signed URL encoding fix)

### DIFF
--- a/src/MetalReleaseTracker.SharedLibraries/Minio/MinioFileStorageService.cs
+++ b/src/MetalReleaseTracker.SharedLibraries/Minio/MinioFileStorageService.cs
@@ -68,6 +68,8 @@ public class MinioFileStorageService : IFileStorageService
                 .WithObject(filePath)
                 .WithExpiry(60 * 60 * 24 * _config.PresignedUrlExpiryDays));
 
+            presignedUrl = System.Web.HttpUtility.UrlDecode(presignedUrl);
+
             if (!string.IsNullOrEmpty(_config.PublicEndpoint))
             {
                 presignedUrl = presignedUrl.Replace($"http://{_config.Endpoint}", _config.PublicEndpoint);


### PR DESCRIPTION
## Summary

Reverts #25. The hypothesis that `HttpUtility.UrlDecode` was causing 403 `SignatureDoesNotMatch` for non-ASCII paths was incorrect.

## What we observed after #25 deployed

- Before #25: image URL for Cyrillic paths had single-encoded form `%D0%B3%D1%80%D0%B0` → 403
- After #25 (deploy at 19:50 UTC): image URL for Cyrillic paths became double-encoded `%25D0%25B3%25D1%2580%25D0%25B0` → still 403

The `UrlDecode` was cancelling one layer of the MinIO .NET SDK's encoding behaviour. Removing it exposed the raw SDK output (double-encoded) but did not change signature validation. Cyrillic object keys were broken before #25 as well — the `UrlDecode` simply normalised the visible URL form.

## Next steps (separate investigation, not this PR)

Real root cause is still open. Candidates to investigate:
1. MinIO .NET SDK v6 canonical URI computation for non-ASCII object keys (signs based on decoded key while server rebuilds canonical URI from encoded URL path).
2. YARP `/storage/` route in CoreDataService — check whether path transform normalises encoding on forward.
3. `ImageUploadService` upload path — verify the key actually stored in MinIO matches what the signed URL refers to (possible double-encoding at upload time landing the file under a literal `%D0...` key).

## Test plan

- [x] `dotnet build` clean (0 errors)
- [ ] Post-deploy: verify ASCII-path album covers still render (regression check — reverts to the pre-#25 behaviour which was known-working for ASCII)
- [ ] Confirm Cyrillic-path covers continue to 403 (pre-existing bug, tracked separately)